### PR TITLE
Improve performance of Mandelbrot iteration

### DIFF
--- a/mandelbrot.go
+++ b/mandelbrot.go
@@ -3,7 +3,6 @@ package main
 import (
 	"image/color"
 	"math"
-	"math/cmplx"
 )
 
 func getColorForComplexNr(c complex128) color.RGBA {
@@ -32,9 +31,9 @@ func runMandelbrot(c complex128) (bool, float64, int) {
 
 	for i := 1; i < imgConf.MaxIter; i++ {
 		z = z*z + c
-		magnitude := cmplx.Abs(z)
-		if magnitude > 2 {
-			return true, magnitude, i
+		magnitudeSquared := real(z)*real(z) + imag(z)*imag(z)
+		if magnitudeSquared > 4 {
+			return true, math.Sqrt(magnitudeSquared), i
 		}
 	}
 	return false, 0, 0

--- a/mandelbrot.go
+++ b/mandelbrot.go
@@ -30,12 +30,12 @@ func getColorFromMandelbrot(isUnlimited bool, magnitude float64, iterations int)
 func runMandelbrot(c complex128) (bool, float64, int) {
 	var z complex128
 
-	for i := 0; i < imgConf.MaxIter; i++ {
+	for i := 1; i < imgConf.MaxIter; i++ {
+		z = z*z + c
 		magnitude := cmplx.Abs(z)
 		if magnitude > 2 {
 			return true, magnitude, i
 		}
-		z = z*z + c
 	}
 	return false, 0, 0
 }


### PR DESCRIPTION
|                                       | base (8ddb4a8)   |              cd346b5   |   vs base    |
|--------------------------------|--------------|---------------------------|--------------|
|                                |   sec/op     |   sec/op                   |              |
| RunMandelbrot/MaxIter_10-4     | 63.10n ± 1%  | 25.34n ± 1%               | -59.83% (p=0.000 n=10) |
| RunMandelbrot/MaxIter_100-4    | 634.8n ± 1%  | 391.6n ± 0%               | -38.32% (p=0.000 n=10) |
| RunMandelbrot/MaxIter_1000-4   | 6.340µ ± 2%  | 4.010µ ± 0%               | -36.75% (p=0.000 n=10) |
| RunMandelbrot/MaxIter_10000-4  | 63.26µ ± 1%  | 40.16µ ± 0%               | -36.51% (p=0.000 n=10) |

